### PR TITLE
Add JWT-protected medical record endpoints and doctor UI

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -482,3 +482,92 @@ def create_appointment():
     db.session.commit()
 
     return jsonify({"msg": "Cita solicitada con éxito"}), 201
+
+
+@api.route('/appointments/<int:appointment_id>/medical-record', methods=['POST'])
+@jwt_required()
+@roles_required(RoleEnum.DOCTOR, RoleEnum.INDEPENDENT_VET)
+def create_medical_record(appointment_id):
+    current_user_id = int(get_jwt_identity())
+    appointment = Appointment.query.get(appointment_id)
+
+    if not appointment:
+        return jsonify({"message": "Cita no encontrada"}), 404
+
+    body = request.get_json(silent=True) or {}
+    diagnostico = body.get("diagnostico")
+    tratamiento = body.get("tratamiento")
+    motivo = body.get("motivo", "Consulta general")
+
+    if not diagnostico or not tratamiento:
+        return jsonify({"message": "Diagnóstico y tratamiento son obligatorios"}), 400
+
+    if appointment.record:
+        return jsonify({"message": "La cita ya tiene una historia clínica registrada"}), 409
+
+    appointment.doctor_id = current_user_id
+    appointment.status = AppointmentStatus.COMPLETADA
+
+    new_record = MedicalRecord(
+        motivo=motivo,
+        diagnostico_tratamiento=f"Diagnóstico: {diagnostico}\nTratamiento: {tratamiento}",
+        pet_id=appointment.pet_id,
+        doctor_id=current_user_id,
+        appointment_id=appointment.id
+    )
+
+    db.session.add(new_record)
+    db.session.commit()
+
+    return jsonify({
+        "message": "Historia clínica registrada con éxito",
+        "record": {
+            "id": new_record.id,
+            "fecha": new_record.fecha.isoformat() if new_record.fecha else None,
+            "motivo": new_record.motivo,
+            "diagnostico": diagnostico,
+            "tratamiento": tratamiento,
+            "pet_id": new_record.pet_id,
+            "appointment_id": new_record.appointment_id
+        }
+    }), 201
+
+
+@api.route('/pets/<int:pet_id>/medical-records', methods=['GET'])
+@jwt_required()
+def get_pet_medical_records(pet_id):
+    current_user_id = int(get_jwt_identity())
+    claims = get_jwt()
+    pet = Pet.query.get(pet_id)
+
+    if not pet:
+        return jsonify({"message": "Mascota no encontrada"}), 404
+
+    is_owner = pet.user_id == current_user_id
+    is_medical_staff = claims.get("role") in [RoleEnum.DOCTOR.value, RoleEnum.INDEPENDENT_VET.value, RoleEnum.CLINIC_ADMIN.value]
+
+    if not is_owner and not is_medical_staff:
+        return jsonify({"message": "No autorizado para ver esta historia clínica"}), 403
+
+    records = MedicalRecord.query.filter_by(pet_id=pet_id).order_by(MedicalRecord.fecha.desc()).all()
+    serialized = []
+    for record in records:
+        diagnostico, tratamiento = "", ""
+        if record.diagnostico_tratamiento and "\nTratamiento: " in record.diagnostico_tratamiento:
+            parts = record.diagnostico_tratamiento.split("\nTratamiento: ", 1)
+            diagnostico = parts[0].replace("Diagnóstico: ", "")
+            tratamiento = parts[1]
+        else:
+            diagnostico = record.diagnostico_tratamiento or ""
+
+        serialized.append({
+            "id": record.id,
+            "fecha": record.fecha.isoformat() if record.fecha else None,
+            "motivo": record.motivo,
+            "diagnostico": diagnostico,
+            "tratamiento": tratamiento,
+            "doctor_id": record.doctor_id,
+            "appointment_id": record.appointment_id
+        })
+
+    return jsonify(serialized), 200

--- a/src/front/components/Navbar.jsx
+++ b/src/front/components/Navbar.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useGlobalReducer } from "../hooks/useGlobalReducer";
 
 export const Navbar = () => {
     const navigate = useNavigate();
+    const { store } = useGlobalReducer();
+    const canRegisterRecord = ["DOCTOR", "INDEPENDENT_VET"].includes(store.user?.role);
 
     return (
         <nav className="navbar navbar-light bg-white border-bottom px-4">
@@ -14,6 +17,14 @@ export const Navbar = () => {
 
                 {/* Lado Derecho: Usuario y Login (Zona Roja de tu imagen) */}
                 <div className="d-flex align-items-center gap-3">
+                    {canRegisterRecord && (
+                        <button
+                            className="btn btn-outline-primary rounded-pill px-3"
+                            onClick={() => navigate("/historia-clinica/registrar")}
+                        >
+                            Historia clínica
+                        </button>
+                    )}
                     <div className="bg-light rounded-circle d-flex align-items-center justify-content-center shadow-sm" 
                          style={{ width: "38px", height: "38px" }}>
                         <i className="fa-solid fa-user text-secondary"></i>

--- a/src/front/pages/MedicalRecordForm.jsx
+++ b/src/front/pages/MedicalRecordForm.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import { useGlobalReducer } from "../hooks/useGlobalReducer";
+
+export const MedicalRecordForm = () => {
+  const { store } = useGlobalReducer();
+  const backendUrl = import.meta.env.VITE_BACKEND_URL;
+  const [appointmentId, setAppointmentId] = useState("");
+  const [motivo, setMotivo] = useState("Consulta general");
+  const [diagnostico, setDiagnostico] = useState("");
+  const [tratamiento, setTratamiento] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage("");
+    setError("");
+
+    try {
+      const response = await fetch(`${backendUrl}/api/appointments/${appointmentId}/medical-record`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${store.token}`
+        },
+        body: JSON.stringify({ motivo, diagnostico, tratamiento })
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data.message || "No se pudo registrar la historia clínica");
+        return;
+      }
+
+      setMessage("Diagnóstico y tratamiento registrados exitosamente.");
+      setDiagnostico("");
+      setTratamiento("");
+      setAppointmentId("");
+    } catch {
+      setError("Error de conexión con el servidor");
+    }
+  };
+
+  return (
+    <div className="container py-5" style={{ maxWidth: "720px" }}>
+      <h2 className="mb-4">Registrar historia clínica</h2>
+      <form onSubmit={handleSubmit} className="card p-4 shadow-sm">
+        <div className="mb-3">
+          <label className="form-label">ID de la cita</label>
+          <input
+            type="number"
+            className="form-control"
+            value={appointmentId}
+            onChange={(e) => setAppointmentId(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label">Motivo de consulta</label>
+          <input
+            type="text"
+            className="form-control"
+            value={motivo}
+            onChange={(e) => setMotivo(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label">Diagnóstico</label>
+          <textarea
+            className="form-control"
+            rows="3"
+            value={diagnostico}
+            onChange={(e) => setDiagnostico(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label">Tratamiento</label>
+          <textarea
+            className="form-control"
+            rows="3"
+            value={tratamiento}
+            onChange={(e) => setTratamiento(e.target.value)}
+            required
+          />
+        </div>
+
+        <button type="submit" className="btn btn-primary">Guardar historia clínica</button>
+
+        {message && <div className="alert alert-success mt-3 mb-0">{message}</div>}
+        {error && <div className="alert alert-danger mt-3 mb-0">{error}</div>}
+      </form>
+    </div>
+  );
+};

--- a/src/front/routes.jsx
+++ b/src/front/routes.jsx
@@ -18,6 +18,7 @@ import { ForcePasswordChange } from "./pages/ForcePasswordChange";
 import { SuperAdminRequests } from "./pages/SuperAdminRequests";
 import { MyPets } from "./pages/MyPets"; 
 import { BookingView } from "./pages/BookingView"; // <--- AGREGADO
+import { MedicalRecordForm } from "./pages/MedicalRecordForm";
 
 const PrivateGuard = ({ children, allowedRoles }) => {
   const { store } = useGlobalReducer();
@@ -50,6 +51,7 @@ export const router = createBrowserRouter(
 
       {/* RUTA DE AGENDAR CITA (PÚBLICA para desarrollo) */}
       <Route path="/agendar-cita" element={<BookingView />} /> {/* <--- AGREGADO */}
+      <Route path="/historia-clinica/registrar" element={<PrivateGuard allowedRoles={["DOCTOR", "INDEPENDENT_VET"]}><MedicalRecordForm /></PrivateGuard>} />
 
       {/* RUTA DE SEGURIDAD (Obligatoria para primer login) */}
       <Route path="/change-password" element={


### PR DESCRIPTION
### Motivation
- Permitir que un médico registre diagnóstico y tratamiento luego de una consulta y que esa información quede guardada en la historia clínica de la mascota con control de acceso mediante JWT y roles.
- Exponer la historia clínica de una mascota para su dueño y personal médico autorizado de forma segura desde el backend y consumible desde la UI.

### Description
- Se agregó el endpoint `POST /api/appointments/<appointment_id>/medical-record` protegido con `@jwt_required()` y `@roles_required(RoleEnum.DOCTOR, RoleEnum.INDEPENDENT_VET)` que crea un `MedicalRecord`, marca la cita como `COMPLETADA` y asigna el `doctor_id` a la cita.
- Se agregó el endpoint `GET /api/pets/<pet_id>/medical-records` protegido con `@jwt_required()` que permite al dueño o al personal médico autorizado listar las historias clínicas de una mascota con serialización sencilla.
- Se creó la vista frontend `src/front/pages/MedicalRecordForm.jsx` que recoge `motivo`, `diagnostico` y `tratamiento` y envía la solicitud con el token JWT en el header `Authorization: Bearer ...` usando la variable de entorno `VITE_BACKEND_URL` como base URL.
- Se añadió la ruta protegida `/historia-clinica/registrar` y se actualizó el `Navbar` para mostrar un acceso rápido a la página cuando el usuario tiene rol `DOCTOR` o `INDEPENDENT_VET`.

### Testing
- Se compiló el backend con `python -m py_compile src/api/routes.py` sin errores. 
- Se ejecutó `npm run -s build` para la UI y la compilación finalizó correctamente (apareció una advertencia no bloqueante sobre tamaño de chunk).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4129cf908832faa69aa849ee07b02)