### PR TITLE
Add doctor-facing appointment endpoints and DoctorDashboard UI

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -35,6 +35,8 @@ def generate_temp_password(length=12):
     return ''.join(secrets.choice(alphabet) for i in range(length))
 
 
+
+
 @api.route('/master-setup', methods=['POST'])
 def master_setup():
     master_key = os.getenv("MASTER_KEY")
@@ -711,34 +713,170 @@ def add_pet():
 @api.route('/appointments', methods=['POST'])
 @jwt_required()
 def create_appointment():
-    user_id = get_jwt_identity()
-    body = request.json
+    body = request.json or {}
 
     if not body.get("pet_id") or not body.get("date"):
         return jsonify({"msg": "Faltan datos obligatorios"}), 400
 
     try:
-        # Limpiamos el formato de la fecha que viene del input datetime-local
-        date_str = body['date'].replace('T', ' ')
         date_obj = datetime.fromisoformat(body['date'].replace('Z', '+00:00'))
     except Exception:
         return jsonify({"msg": "Formato de fecha inválido"}), 400
 
-    # Buscamos la primera clínica activa para asignar la cita
-    clinic = Clinic.query.filter_by(is_active=True).first()
-    if not clinic:
+    pet = Pet.query.get(body['pet_id'])
+    if not pet:
+        return jsonify({"msg": "Mascota no encontrada"}), 404
+
+    clinic_id = body.get('clinic_id')
+    doctor_id = body.get('doctor_id')
+
+    clinic = Clinic.query.get(clinic_id) if clinic_id else Clinic.query.filter_by(is_active=True).first()
+    if not clinic or not clinic.is_active:
         return jsonify({"msg": "No hay clínicas disponibles"}), 404
+
+    doctor = None
+    if doctor_id:
+        doctor = User.query.get(doctor_id)
+        if not doctor or doctor.role != RoleEnum.DOCTOR:
+            return jsonify({"msg": "Doctor no válido"}), 400
+        if doctor.clinic_id != clinic.id:
+            return jsonify({"msg": "El doctor debe pertenecer a la clínica seleccionada"}), 400
 
     new_appointment = Appointment(
         date_time=date_obj,
         tipo=body.get('service_type', 'Consulta'),
-        status=AppointmentStatus.PROGRAMADA,  # Estado inicial "Pendiente"
-        pet_id=body['pet_id'],
+        status=AppointmentStatus.PROGRAMADA,
+        pet_id=pet.id,
         clinic_id=clinic.id,
-        user_id=user_id
+        doctor_id=doctor.id if doctor else None
     )
 
     db.session.add(new_appointment)
     db.session.commit()
 
-    return jsonify({"msg": "Cita solicitada con éxito"}), 201
+    appointment_data = {
+        "id": new_appointment.id,
+        "date_time": new_appointment.date_time.isoformat() if new_appointment.date_time else None,
+        "status": new_appointment.status.value if new_appointment.status else None,
+        "tipo": new_appointment.tipo,
+        "clinic_id": new_appointment.clinic_id,
+        "doctor": {"id": new_appointment.doctor.id if new_appointment.doctor else None, "full_name": new_appointment.doctor.full_name if new_appointment.doctor else None},
+        "pet": {"id": new_appointment.pet.id if new_appointment.pet else None, "nombre": new_appointment.pet.nombre if new_appointment.pet else None},
+        "has_medical_record": new_appointment.record is not None
+    }
+
+    return jsonify({"msg": "Cita solicitada con éxito", "appointment": appointment_data}), 201
+
+
+@api.route('/doctor/appointments', methods=['GET'])
+@jwt_required()
+@roles_required(RoleEnum.DOCTOR)
+def get_doctor_appointments():
+    doctor_id = int(get_jwt_identity())
+    claims = get_jwt()
+    clinic_id = claims.get("clinic_id")
+
+    appointments = Appointment.query.filter_by(clinic_id=clinic_id, doctor_id=doctor_id).order_by(Appointment.date_time.asc()).all()
+    appointments_data = []
+    for appointment in appointments:
+        appointments_data.append({
+            "id": appointment.id,
+            "date_time": appointment.date_time.isoformat() if appointment.date_time else None,
+            "status": appointment.status.value if appointment.status else None,
+            "tipo": appointment.tipo,
+            "clinic_id": appointment.clinic_id,
+            "doctor": {"id": appointment.doctor.id if appointment.doctor else None, "full_name": appointment.doctor.full_name if appointment.doctor else None},
+            "pet": {
+                "id": appointment.pet.id if appointment.pet else None,
+                "nombre": appointment.pet.nombre if appointment.pet else None,
+                "especie": appointment.pet.especie if appointment.pet else None,
+                "raza": appointment.pet.raza if appointment.pet else None,
+                "edad": appointment.pet.edad if appointment.pet else None,
+                "owner_name": appointment.pet.owner.full_name if appointment.pet and appointment.pet.owner else None,
+                "owner_email": appointment.pet.owner.email if appointment.pet and appointment.pet.owner else None
+            },
+            "has_medical_record": appointment.record is not None
+        })
+    return jsonify(appointments_data), 200
+
+
+@api.route('/doctor/appointments/<int:appointment_id>/status', methods=['PATCH'])
+@jwt_required()
+@roles_required(RoleEnum.DOCTOR)
+def update_doctor_appointment_status(appointment_id):
+    doctor_id = int(get_jwt_identity())
+    appointment = Appointment.query.get(appointment_id)
+    if not appointment or appointment.doctor_id != doctor_id:
+        return jsonify({"message": "Cita no encontrada"}), 404
+
+    body = request.json or {}
+    status = body.get("status")
+    valid = {s.value for s in AppointmentStatus}
+    if status not in valid:
+        return jsonify({"message": "Estado inválido"}), 400
+
+    appointment.status = AppointmentStatus(status)
+    db.session.commit()
+    appointment_data = {"id": appointment.id, "status": appointment.status.value, "date_time": appointment.date_time.isoformat() if appointment.date_time else None}
+    return jsonify({"message": "Estado actualizado", "appointment": appointment_data}), 200
+
+
+@api.route('/doctor/patients', methods=['GET'])
+@jwt_required()
+@roles_required(RoleEnum.DOCTOR)
+def get_doctor_patients():
+    doctor_id = int(get_jwt_identity())
+    appointments = Appointment.query.filter_by(doctor_id=doctor_id).all()
+    pets = {a.pet.id: a.pet for a in appointments if a.pet}
+
+    result = []
+    for pet in pets.values():
+        history = MedicalRecord.query.filter_by(pet_id=pet.id).order_by(MedicalRecord.fecha.desc()).all()
+        result.append({
+            "id": pet.id,
+            "nombre": pet.nombre,
+            "especie": pet.especie,
+            "raza": pet.raza,
+            "edad": pet.edad,
+            "owner_name": pet.owner.full_name if pet.owner else None,
+            "owner_email": pet.owner.email if pet.owner else None,
+            "medical_history": [{"id": r.id, "fecha": r.fecha.isoformat() if r.fecha else None, "motivo": r.motivo, "diagnostico_tratamiento": r.diagnostico_tratamiento, "doctor": {"id": r.doctor.id if r.doctor else None, "full_name": r.doctor.full_name if r.doctor else None}} for r in history]
+        })
+
+    return jsonify(result), 200
+
+
+@api.route('/doctor/appointments/<int:appointment_id>/consultation', methods=['POST'])
+@jwt_required()
+@roles_required(RoleEnum.DOCTOR)
+def save_consultation(appointment_id):
+    doctor_id = int(get_jwt_identity())
+    appointment = Appointment.query.get(appointment_id)
+    if not appointment or appointment.doctor_id != doctor_id:
+        return jsonify({"message": "Cita no encontrada"}), 404
+
+    body = request.json or {}
+    motivo = body.get("motivo")
+    diagnostico = body.get("diagnostico_tratamiento")
+    if not motivo or not diagnostico:
+        return jsonify({"message": "Motivo y diagnóstico/tratamiento son obligatorios"}), 400
+
+    record = MedicalRecord.query.filter_by(appointment_id=appointment.id).first()
+    if record:
+        record.motivo = motivo
+        record.diagnostico_tratamiento = diagnostico
+    else:
+        record = MedicalRecord(
+            pet_id=appointment.pet_id,
+            doctor_id=doctor_id,
+            appointment_id=appointment.id,
+            motivo=motivo,
+            diagnostico_tratamiento=diagnostico
+        )
+        db.session.add(record)
+
+    appointment.status = AppointmentStatus.COMPLETADA
+    db.session.commit()
+
+    medical_record_data = {"id": record.id, "fecha": record.fecha.isoformat() if record.fecha else None, "motivo": record.motivo, "diagnostico_tratamiento": record.diagnostico_tratamiento}
+    return jsonify({"message": "Consulta guardada", "medical_record": medical_record_data}), 200

--- a/src/front/hooks/useGlobalReducer.jsx
+++ b/src/front/hooks/useGlobalReducer.jsx
@@ -210,6 +210,75 @@ export function StoreProvider({ children }) {
             }
         },
 
+
+        getDoctorAppointments: async () => {
+            try {
+                const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/doctor/appointments`, {
+                    headers: { "Authorization": "Bearer " + store.token }
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    dispatch({ type: "set_doctor_appointments", payload: data });
+                    return { success: true, data };
+                }
+                return { success: false, message: data.message || "No se pudieron cargar las citas" };
+            } catch (error) {
+                console.error("Error cargando citas del doctor:", error);
+                return { success: false, message: "Error de conexión" };
+            }
+        },
+
+        getDoctorPatients: async () => {
+            try {
+                const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/doctor/patients`, {
+                    headers: { "Authorization": "Bearer " + store.token }
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    dispatch({ type: "set_doctor_patients", payload: data });
+                    return { success: true, data };
+                }
+                return { success: false, message: data.message || "No se pudieron cargar los pacientes" };
+            } catch (error) {
+                console.error("Error cargando pacientes del doctor:", error);
+                return { success: false, message: "Error de conexión" };
+            }
+        },
+
+        updateDoctorAppointmentStatus: async (appointmentId, status) => {
+            try {
+                const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/doctor/appointments/${appointmentId}/status`, {
+                    method: "PATCH",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer " + store.token
+                    },
+                    body: JSON.stringify({ status })
+                });
+                return resp.ok;
+            } catch (error) {
+                console.error("Error actualizando estado de cita:", error);
+                return false;
+            }
+        },
+
+        saveDoctorConsultation: async (appointmentId, consultation) => {
+            try {
+                const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/doctor/appointments/${appointmentId}/consultation`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer " + store.token
+                    },
+                    body: JSON.stringify(consultation)
+                });
+                return resp.ok;
+            } catch (error) {
+                console.error("Error guardando consulta:", error);
+                return false;
+            }
+        },
+
         logout: () => {
             localStorage.removeItem("token");
             localStorage.removeItem("user");

--- a/src/front/pages/DoctorDashboard.jsx
+++ b/src/front/pages/DoctorDashboard.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useGlobalReducer } from "../hooks/useGlobalReducer";
+
+export const DoctorDashboard = () => {
+  const { store, actions } = useGlobalReducer();
+  const [activeTab, setActiveTab] = useState("dashboard");
+  const [selectedAppointment, setSelectedAppointment] = useState(null);
+  const [consultation, setConsultation] = useState({ motivo: "", diagnostico_tratamiento: "" });
+
+  const loadData = async () => {
+    await Promise.all([actions.getDoctorAppointments(), actions.getDoctorPatients()]);
+  };
+
+  useEffect(() => { loadData(); }, []);
+
+  const kpis = useMemo(() => ({
+    total: store.doctorAppointments.length,
+    enAtencion: store.doctorAppointments.filter(a => a.status === "EN_ATENCION").length,
+    programadas: store.doctorAppointments.filter(a => a.status === "PROGRAMADA").length,
+    completadas: store.doctorAppointments.filter(a => a.status === "COMPLETADA").length,
+  }), [store.doctorAppointments]);
+
+  const changeStatus = async (appointmentId, status) => {
+    await actions.updateDoctorAppointmentStatus(appointmentId, status);
+    loadData();
+  };
+
+  const saveConsultation = async () => {
+    if (!selectedAppointment) return;
+    await actions.saveDoctorConsultation(selectedAppointment.id, consultation);
+    setConsultation({ motivo: "", diagnostico_tratamiento: "" });
+    setSelectedAppointment(null);
+    loadData();
+  };
+
+  return (
+    <div className="container py-4">
+      <h2 className="mb-3">Panel del Doctor</h2>
+      <div className="d-flex gap-2 flex-wrap mb-4">
+        {[
+          ["dashboard", "Dashboard"],
+          ["schedule", "Schedule"],
+          ["patients", "Pacientes"],
+        ].map(([id, label]) => (
+          <button key={id} className={`btn ${activeTab === id ? "btn-primary" : "btn-outline-primary"}`} onClick={() => setActiveTab(id)}>{label}</button>
+        ))}
+      </div>
+
+      {activeTab === "dashboard" && (
+        <div className="row g-3">
+          <div className="col-6 col-md-3"><div className="card p-3"><strong>Total</strong><span>{kpis.total}</span></div></div>
+          <div className="col-6 col-md-3"><div className="card p-3"><strong>Programadas</strong><span>{kpis.programadas}</span></div></div>
+          <div className="col-6 col-md-3"><div className="card p-3"><strong>En atención</strong><span>{kpis.enAtencion}</span></div></div>
+          <div className="col-6 col-md-3"><div className="card p-3"><strong>Completadas</strong><span>{kpis.completadas}</span></div></div>
+        </div>
+      )}
+
+      {activeTab === "schedule" && (
+        <div className="table-responsive">
+          <table className="table align-middle">
+            <thead><tr><th>Fecha</th><th>Mascota</th><th>Estado</th><th>Acciones</th></tr></thead>
+            <tbody>
+              {store.doctorAppointments.map(ap => (
+                <tr key={ap.id}>
+                  <td>{new Date(ap.date_time).toLocaleString()}</td>
+                  <td>{ap.pet?.nombre}</td>
+                  <td>{ap.status}</td>
+                  <td className="d-flex gap-2 flex-wrap">
+                    <button className="btn btn-sm btn-warning" onClick={() => changeStatus(ap.id, "EN_ATENCION")}>En atención</button>
+                    <button className="btn btn-sm btn-secondary" onClick={() => changeStatus(ap.id, "CANCELADA")}>Cancelar</button>
+                    <button className="btn btn-sm btn-success" onClick={() => { setSelectedAppointment(ap); setConsultation({ motivo: "", diagnostico_tratamiento: "" }); }}>Finalizar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {selectedAppointment && (
+            <div className="card p-3 mt-3">
+              <h5>Finalizar consulta: {selectedAppointment.pet?.nombre}</h5>
+              <input className="form-control mb-2" placeholder="Motivo" value={consultation.motivo} onChange={e => setConsultation({ ...consultation, motivo: e.target.value })} />
+              <textarea className="form-control mb-2" rows="4" placeholder="Diagnóstico y tratamiento" value={consultation.diagnostico_tratamiento} onChange={e => setConsultation({ ...consultation, diagnostico_tratamiento: e.target.value })} />
+              <button className="btn btn-primary" onClick={saveConsultation}>Guardar y completar</button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === "patients" && (
+        <div className="row g-3">
+          {store.doctorPatients.map(p => (
+            <div key={p.id} className="col-12 col-lg-6">
+              <div className="card p-3 h-100">
+                <h5>{p.nombre} <small className="text-muted">({p.especie})</small></h5>
+                <p className="mb-2">Dueño: {p.owner_name} · {p.owner_email}</p>
+                <strong>Historia clínica:</strong>
+                <ul className="mb-0">
+                  {p.medical_history.length === 0 ? <li>Sin registros</li> : p.medical_history.map(r => <li key={r.id}>{new Date(r.fecha).toLocaleDateString()} - {r.motivo}</li>)}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/front/routes.jsx
+++ b/src/front/routes.jsx
@@ -21,6 +21,7 @@ import { BookingView } from "./pages/BookingView"; // <--- AGREGADO
 import { ClinicDashboard } from "./pages/ClinicDashboard";
 import { RegisterStaff } from "./pages/RegisterStaffNewEmployee";
 import { RegisterWithCode } from "./pages/RegisterWithCode";
+import { DoctorDashboard } from "./pages/DoctorDashboard";
 
 const PrivateGuard = ({ children, allowedRoles }) => {
   const { store } = useGlobalReducer();
@@ -77,6 +78,8 @@ export const router = createBrowserRouter(
       <Route path="admin/clinicas" element={<PrivateGuard allowedRoles={["SUPER_ADMIN"]}><AdminClinics /></PrivateGuard>} />
       <Route path="/admin/solicitudes" element={<PrivateGuard allowedRoles={["SUPER_ADMIN"]}> <SuperAdminRequests /> </PrivateGuard>} />
       <Route path="/clinic/admin" element={<PrivateGuard allowedRoles={["CLINIC_ADMIN","INDEPENDENT_VET"]}><ClinicDashboard /></PrivateGuard>} />
+      <Route path="/doctor" element={<PrivateGuard allowedRoles={["DOCTOR"]}><DoctorDashboard /></PrivateGuard>} />
+
 
       <Route path="/item2" element={<div className="container py-5 text-center"><h1>Página Item 2</h1><p>En construcción...</p></div>} />
       <Route path="/item3" element={<div className="container py-5 text-center"><h1>Página Item 3</h1><p>En construcción...</p></div>} />

--- a/src/front/store.js
+++ b/src/front/store.js
@@ -10,6 +10,8 @@ export const initialStore = () => {
     clinics: [],
     clinicRequests: [],
     staff: [],
+    doctorAppointments: [],
+    doctorPatients: []
   };
 };
 
@@ -68,6 +70,19 @@ export default function storeReducer(store, action) {
       return {
         ...store,
         clinicRequests: store.clinicRequests.filter(req => req.id !== action.payload)
+      };
+
+
+    case 'set_doctor_appointments':
+      return {
+        ...store,
+        doctorAppointments: action.payload
+      };
+
+    case 'set_doctor_patients':
+      return {
+        ...store,
+        doctorPatients: action.payload
       };
 
     case 'update_user_locally':


### PR DESCRIPTION
### Motivation
- Expose doctor-specific workflows for managing appointments, consultations and patient histories from the API. 
- Improve appointment creation to allow selecting clinic and doctor, validate inputs and return enriched appointment payloads. 
- Add a doctor-facing single-page UI and client actions so doctors can view, update and complete consultations. 

### Description
- Backend: updated `src/api/routes.py` to enhance `create_appointment` with pet validation, optional `clinic_id` and `doctor_id`, doctor/clinic ownership checks, and a richer JSON response for created appointments. 
- Backend: added doctor endpoints `GET /api/doctor/appointments`, `PATCH /api/doctor/appointments/<id>/status`, `GET /api/doctor/patients`, and `POST /api/doctor/appointments/<id>/consultation` with `@roles_required(RoleEnum.DOCTOR)` protection and logic to read/update `Appointment` and `MedicalRecord`. 
- Frontend: added `DoctorDashboard` component at `src/front/pages/DoctorDashboard.jsx` and registered the route at `/doctor` in `src/front/routes.jsx`. 
- Frontend: extended global state with `doctorAppointments` and `doctorPatients` in `src/front/store.js`, added reducer cases `set_doctor_appointments` and `set_doctor_patients`, and implemented client actions in `src/front/hooks/useGlobalReducer.jsx` (`getDoctorAppointments`, `getDoctorPatients`, `updateDoctorAppointmentStatus`, `saveDoctorConsultation`). 

### Testing
- No automated tests were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92c88cc10832f94bf84fb5cad88b6)